### PR TITLE
Add helpers to extract values from a context

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -8,8 +8,9 @@ val Scala13 = "2.13.8"
 
 val CatsCore = ivy"org.typelevel::cats-core:2.7.0"
 val CatsParse = ivy"org.typelevel::cats-parse:0.3.7"
-
+val CatsEffect = ivy"org.typelevel::cats-effect:3.3.14"
 val SuperTagged = ivy"org.rudogma::supertagged:2.0-RC2"
+val SourceCode = ivy"com.lihaoyi::sourcecode:0.3.0"
 
 val ScalaCheck = ivy"org.scalacheck::scalacheck:1.16.0"
 val ScalaTest = ivy"org.scalatest::scalatest:3.2.13"
@@ -19,6 +20,7 @@ val PropSpec = Set(
   ivy"org.scalatest::scalatest-propspec:3.2.13",
   ivy"org.scalatestplus::scalacheck-1-16:3.2.12.0"
 )
+val MUnit = ivy"org.scalameta::munit:0.7.29"
 
 trait StyleModule extends ScalafmtModule with ScalafixModule {
   override def scalafixIvyDeps = super.scalafixIvyDeps() ++ Agg(ivy"com.github.liancheng::organize-imports:0.6.0")
@@ -35,6 +37,8 @@ trait StyleModule extends ScalafmtModule with ScalafixModule {
     "-Xfatal-warnings",
     "-language:higherKinds"
   )
+
+  override def forkEnv: T[Map[String, String]] = super.forkEnv().updated("SCALACTIC_FILL_FILE_PATHNAMES", "yes")
 
   def versionSpecificOptions(version: String) = version match {
     case Scala12 =>
@@ -87,13 +91,14 @@ trait CommonModule
   protected def outerCrossScalaVersion: String = crossScalaVersion
 }
 
-trait CommonTestModule extends TestModule.ScalaTest with StyleModule
+trait UsingScalaTestModule extends TestModule.ScalaTest with StyleModule
+trait UsingMunitTestModule extends TestModule.Munit with StyleModule
 
 object core extends Cross[CoreModule](Scala12, Scala13)
 class CoreModule(val crossScalaVersion: String) extends CommonModule {
   override def ivyDeps = Agg(CatsCore, CatsParse, SuperTagged)
 
-  object test extends Tests with CommonTestModule {
+  object test extends Tests with UsingScalaTestModule {
     override def moduleDeps: Seq[JavaModule] =
       super.moduleDeps ++ Seq(scalacheck(crossScalaVersion))
 
@@ -109,7 +114,7 @@ object collections extends Cross[CollectionsModule](Scala12, Scala13)
 class CollectionsModule(val crossScalaVersion: String) extends CommonModule {
   override def ivyDeps: T[Agg[Dep]] = super.ivyDeps() ++ Agg(CatsCore)
 
-  object test extends Tests with CommonTestModule {
+  object test extends Tests with UsingScalaTestModule {
     override def moduleDeps: Seq[JavaModule] =
       super.moduleDeps ++ Seq(scalacheck(crossScalaVersion))
 
@@ -128,7 +133,7 @@ class ScalaCheckModule(val crossScalaVersion: String) extends CommonModule {
     collections(crossScalaVersion)
   )
 
-  object test extends Tests with CommonTestModule {
+  object test extends Tests with UsingScalaTestModule {
     override def crossScalaVersion: String = outerCrossScalaVersion
 
     override def ivyDeps: T[Agg[Dep]] = super.ivyDeps() ++ Agg.from(PropSpec)
@@ -149,7 +154,44 @@ object shims extends Cross[ShimsModule](Scala12, Scala13)
 class ShimsModule(val crossScalaVersion: String) extends CommonModule {
   override def moduleDeps: Seq[PublishModule] = super.moduleDeps ++ Seq(core(crossScalaVersion))
 
-  object test extends Tests with CommonTestModule {
+  object test extends Tests with UsingScalaTestModule {
+    override def crossScalaVersion: String = outerCrossScalaVersion
+
+    override def ivyDeps: T[Agg[Dep]] = super.ivyDeps() ++ Agg.from(WordSpec)
+  }
+}
+
+object testing extends Cross[TestingModule](Scala12, Scala13)
+class TestingModule(val crossScalaVersion: String) extends CommonModule {
+  override def ivyDeps: T[Agg[Dep]] = super.ivyDeps() ++ Seq(SourceCode, SuperTagged, CatsEffect, CatsCore)
+
+  object test extends Tests with UsingMunitTestModule {
+    override def crossScalaVersion: String = outerCrossScalaVersion
+
+    override def ivyDeps: T[Agg[Dep]] = super.ivyDeps() ++ Agg(MUnit)
+  }
+}
+
+object munit extends Cross[MunitModule](Scala12, Scala13)
+class MunitModule(val crossScalaVersion: String) extends CommonModule {
+  override def ivyDeps: T[Agg[Dep]] = super.ivyDeps() ++ Seq(MUnit)
+
+  override def moduleDeps: Seq[PublishModule] = super.moduleDeps :+ testing(crossScalaVersion)
+
+  object test extends Tests with UsingMunitTestModule {
+    override def crossScalaVersion: String = outerCrossScalaVersion
+
+    override def ivyDeps: T[Agg[Dep]] = super.ivyDeps() ++ Agg(MUnit)
+  }
+}
+
+object scalatest extends Cross[ScalaTestModule](Scala12, Scala13)
+class ScalaTestModule(val crossScalaVersion: String) extends CommonModule {
+  override def ivyDeps: T[Agg[Dep]] = super.ivyDeps() ++ Seq(ScalaTest)
+
+  override def moduleDeps: Seq[PublishModule] = super.moduleDeps :+ testing(crossScalaVersion)
+
+  object test extends Tests with UsingScalaTestModule {
     override def crossScalaVersion: String = outerCrossScalaVersion
 
     override def ivyDeps: T[Agg[Dep]] = super.ivyDeps() ++ Agg.from(WordSpec)

--- a/munit/src/peschke/munit/MUnitValueExtractors.scala
+++ b/munit/src/peschke/munit/MUnitValueExtractors.scala
@@ -1,0 +1,30 @@
+package peschke.munit
+
+import munit.Location
+import peschke.testing.At
+import peschke.testing.Fail
+import peschke.testing.ValueExtractor
+import sourcecode.Text
+
+/** Provides instances so [[peschke.testing.ValueExtractor.Syntax]] can be used
+  * in munit tests
+  */
+trait MUnitValueExtractors extends ValueExtractor.Syntax[Location] {
+  _: munit.Assertions =>
+  implicit val failUsingMunitAssertions: Fail[Location] = new Fail[Location] {
+    override def apply[A](msg: String, sourceInfo: Text[A], location: Location)
+      : Nothing = {
+      fail(s"${sourceInfo.source} $msg")(location)
+    }
+
+    override def apply[A]
+      (msg: String, sourceInfo: Text[A], cause: Throwable, location: Location)
+      : Nothing = {
+      fail(s"${sourceInfo.source} $msg", cause)(location)
+    }
+  }
+
+  implicit val AtToLocation: At.To[Location] = at =>
+    new Location(at.path.value, at.line.value)
+}
+object MUnitValueExtractors extends MUnitValueExtractors with munit.Assertions

--- a/munit/test/src/peschke/munit/MUnitValueExtractorsTest.scala
+++ b/munit/test/src/peschke/munit/MUnitValueExtractorsTest.scala
@@ -1,0 +1,207 @@
+package peschke.munit
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import cats.syntax.all._
+import munit.FailException
+import munit.Location
+import peschke.testing.ValueExtractor.Timeouts
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
+
+class SmallError(msg: String)
+    extends IllegalArgumentException(msg)
+    with NoStackTrace
+
+class MUnitValueExtractorsTest
+    extends munit.FunSuite
+    with MUnitValueExtractors {
+  implicit private val runtime: IORuntime = IORuntime.global
+  implicit private val executionContext: ExecutionContext =
+    ExecutionContext.global
+
+  private val rightAway = 1.seconds
+  private val quick     = 2.seconds
+  implicit val timeouts: Timeouts = Timeouts(rightAway, rightAway)
+
+  private def path(implicit loc: Location): String = loc.path
+  private def l(implicit loc: Location):    Int    = loc.line
+  private val <<< = "\u001b[7m" // Terminal control to start highlighting text
+  private val >>> = "\u001b[0m" // Terminal control to stop highlighting text
+  private val ___ = "" // For padding, to make writing the expected results much, much, easier.
+
+  test("valueOf[Option[_]] should succeed on a Some(_)") {
+    assertEquals(valueOf(5.some), 5)
+  }
+
+  test("valueOf[Option] should fail on a None") {
+    val cachedLoc = implicitly[Location]
+    try {
+      valueOf(Option.empty[Int])
+      fail("Should have failed")
+    }
+    catch {
+      case tf: FailException =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          tf.message,
+          s"""|$path:${l + 2} Option.empty[Int] was None
+              |${___}${l + 1}:    try {
+              |${<<<}${l + 2}:      valueOf(Option.empty[Int])${>>>}
+              |${___}${l + 3}:      fail("Should have failed")""".stripMargin
+        )
+    }
+  }
+
+  test("valueOf[Either[_,_]] should succeed on a Right(_)") {
+    assertEquals(valueOf(Either.right[String, Int](5)), 5)
+  }
+
+  test("valueOf[Either[_,_]] should fail on a Left(_)") {
+    val cachedLoc = implicitly[Location]
+    try {
+      valueOf(Either.left[String, Int]("oops!"))
+      fail("Should have failed")
+    }
+    catch {
+      case tf: FailException =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          tf.message,
+          s"""|$path:${l + 2} Either.left[String, Int]("oops!") was a Left(oops!) rather than a Right(_)
+              |${___}${l + 1}:    try {
+              |${<<<}${l + 2}:      valueOf(Either.left[String, Int]("oops!"))${>>>}
+              |${___}${l + 3}:      fail("Should have failed")""".stripMargin
+        )
+    }
+  }
+
+  test("valueOf[IO] should succeed if the IO succeeds and none of the finalizers time out") {
+    assertEquals(valueOf(IO.pure(5)), 5)
+  }
+
+  test("valueOf[IO] should fail if the IO fails") {
+    val cachedLoc = implicitly[Location]
+    try {
+      valueOf(IO.raiseError[Int](new SmallError("Oops!")))
+      fail("Should have failed")
+    }
+    catch {
+      case tf: FailException =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          tf.message,
+          s"""|$path:${l + 2} IO.raiseError[Int](new SmallError("Oops!")) failed (SmallError: Oops!)
+              |${___}${l + 1}:    try {
+              |${<<<}${l + 2}:      valueOf(IO.raiseError[Int](new SmallError("Oops!")))${>>>}
+              |${___}${l + 3}:      fail("Should have failed")""".stripMargin
+        )
+    }
+  }
+
+  test("valueOf[IO] should fail if the IO times out") {
+    val cachedLoc = implicitly[Location]
+    try {
+      valueOf(IO.sleep(quick).as(5))
+      fail("Should have failed")
+    }
+    catch {
+      case tf: FailException =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          tf.message,
+          s"""|$path:${l + 2} IO.sleep(quick).as(5) timed out after $rightAway
+              |${___}${l + 1}:    try {
+              |${<<<}${l + 2}:      valueOf(IO.sleep(quick).as(5))${>>>}
+              |${___}${l + 3}:      fail("Should have failed")""".stripMargin
+        )
+    }
+  }
+
+  test("valueOf[IO] should fail if the IO finalizers time out") {
+    val long      = IO.sleep(3.seconds)
+    val cachedLoc = implicitly[Location]
+    try {
+      valueOf(IO.pure(5).guaranteeCase(_ => long))
+      fail("Should have failed")
+    }
+    catch {
+      case tf: FailException =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          tf.message,
+          s"""|$path:${l + 2} IO.pure(5).guaranteeCase(_ => long) timed out while running finalizers, after $quick
+              |${___}${l + 1}:    try {
+              |${<<<}${l + 2}:      valueOf(IO.pure(5).guaranteeCase(_ => long))${>>>}
+              |${___}${l + 3}:      fail("Should have failed")""".stripMargin
+        )
+    }
+  }
+
+  test("valueOf[IO] should fail if the IO finalizers fail") {
+    val cachedLoc = implicitly[Location]
+    try {
+      valueOf(
+        IO.pure(5).guaranteeCase(_ => IO.raiseError(new SmallError("Oops!")))
+      )
+      fail("Should have failed")
+    }
+    catch {
+      case tf: FailException =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          tf.message,
+          s"""|$path:${l + 2} IO.pure(5).guaranteeCase(_ => IO.raiseError(new SmallError("Oops!"))) failed (SmallError: Oops!)
+              |${___}${l + 1}:    try {
+              |${<<<}${l + 2}:      valueOf(${>>>}
+              |${___}${l + 3}:        IO.pure(5).guaranteeCase(_ => IO.raiseError(new SmallError("Oops!")))""".stripMargin
+        )
+    }
+  }
+
+  test("valueOf[Future] should succeed if the Future succeeds") {
+    assertEquals(valueOf(Future.successful(5)), 5)
+  }
+
+  test("valueOf[Future] should fail if the Future fails") {
+    val cachedLoc = implicitly[Location]
+    try {
+      valueOf(Future.failed[Int](new SmallError("Oops!")))
+      fail("Should have failed")
+    }
+    catch {
+      case ae: AssertionError =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          ae.getMessage,
+          s"""|$path:${l + 2} Future.failed[Int](new SmallError("Oops!")) failed (SmallError: Oops!)
+              |${___}${l + 1}:    try {
+              |${<<<}${l + 2}:      valueOf(Future.failed[Int](new SmallError("Oops!")))${>>>}
+              |${___}${l + 3}:      fail("Should have failed")""".stripMargin
+        )
+    }
+  }
+
+  test("valueOf[Future] should fail if the Future times out") {
+    def sleepFor(fd: FiniteDuration) = Future(Thread.sleep(fd.toMillis)).as(5)
+    val cachedLoc                    = implicitly[Location]
+    try {
+      valueOf(sleepFor(10.seconds))
+      fail("Should have failed")
+    }
+    catch {
+      case ae: AssertionError =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          ae.getMessage,
+          s"""|$path:${l + 2} sleepFor(10.seconds) timed out after ${timeouts.total}
+              |${___}${l + 1}:    try {
+              |${<<<}${l + 2}:      valueOf(sleepFor(10.seconds))${>>>}
+              |${___}${l + 3}:      fail("Should have failed")""".stripMargin
+        )
+    }
+  }
+}

--- a/scalatest/src/peschke/scalatest/ScalaTestValueExtractors.scala
+++ b/scalatest/src/peschke/scalatest/ScalaTestValueExtractors.scala
@@ -1,0 +1,39 @@
+package peschke.scalatest
+
+import org.scalactic.source.Position
+import peschke.testing.At
+import peschke.testing.Fail
+import peschke.testing.ValueExtractor
+import sourcecode.Text
+
+/** Provides instances so [[peschke.testing.ValueExtractor.Syntax]] can be used
+  * in scalatest tests
+  */
+trait ScalaTestValueExtractors extends ValueExtractor.Syntax[Position] {
+  _: org.scalatest.Assertions =>
+  implicit val failUsingScalaTestAssertions: Fail[Position] =
+    new Fail[Position] {
+      override def apply[A]
+        (msg: String, sourceInfo: Text[A], position: Position)
+        : Nothing = {
+        fail(s"${position.filePathname}:${position.lineNumber} ${sourceInfo.source} $msg")(
+          position
+        )
+      }
+
+      override def apply[A]
+        (msg: String, sourceInfo: Text[A], cause: Throwable, position: Position)
+        : Nothing = {
+        fail(
+          s"${position.filePathname}:${position.lineNumber} ${sourceInfo.source} $msg",
+          cause
+        )(position)
+      }
+    }
+
+  implicit val AtToPosition: At.To[Position] = at =>
+    new Position(at.name.value, at.path.value, at.line.value)
+}
+object ScalaTestValueExtractors
+    extends ScalaTestValueExtractors
+    with org.scalatest.Assertions

--- a/scalatest/test/src/peschke/scalatest/ScalaTestValueExtractorsTest.scala
+++ b/scalatest/test/src/peschke/scalatest/ScalaTestValueExtractorsTest.scala
@@ -1,0 +1,182 @@
+package peschke.scalatest
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import cats.syntax.all._
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import peschke.testing.At
+import peschke.testing.ValueExtractor.Timeouts
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.FiniteDuration
+import scala.util.control.NoStackTrace
+
+class SmallError(msg: String)
+    extends IllegalArgumentException(msg)
+    with NoStackTrace
+
+class ScalaTestValueExtractorsTest
+    extends AnyWordSpec
+    with Matchers
+    with ScalaTestValueExtractors {
+  implicit private val runtime: IORuntime = IORuntime.global
+  implicit private val executionContext: ExecutionContext =
+    ExecutionContext.global
+
+  private val rightAway = 1.seconds
+  private val quick     = 2.seconds
+  implicit val timeouts: Timeouts = Timeouts(rightAway, rightAway)
+
+  private def path(implicit loc: At): String = loc.path.value
+
+  private def l(implicit loc: At): Int = loc.line.value
+
+  "valueOf[Option[_]]" should {
+    "succeed on a Some(_)" in {
+      valueOf(5.some) mustBe 5
+    }
+
+    "fail on a None" in {
+      val cachedLoc = At.here
+      try {
+        valueOf(Option.empty[Int])
+        fail("Should have failed")
+      }
+      catch {
+        case tfe: TestFailedException =>
+          implicit val loc: At = cachedLoc
+          tfe.getMessage mustBe s"""$path:${l + 2} Option.empty[Int] was None"""
+      }
+    }
+  }
+
+  "valueOf[Either[_,_]]" should {
+    "succeed on a Right(_)" in {
+      valueOf(Either.right[String, Int](5)) mustBe 5
+    }
+
+    "fail on a Left(_)" in {
+      val cachedLoc = At.here
+      try {
+        valueOf(Either.left[String, Int]("oops!"))
+        fail("Should have failed")
+      }
+      catch {
+        case tfe: TestFailedException =>
+          implicit val loc: At = cachedLoc
+          tfe.getMessage mustBe {
+            s"""$path:${l + 2} Either.left[String, Int]("oops!") was a Left(oops!) rather than a Right(_)"""
+          }
+      }
+    }
+  }
+
+  "valueOf[IO]" should {
+    "succeed if the IO succeeds and none of the finalizers time out" in {
+      valueOf(IO.pure(5)) mustBe 5
+    }
+
+    "fail if the IO fails" in {
+      val cachedLoc = At.here
+      try {
+        valueOf(IO.raiseError[Int](new SmallError("Oops!")))
+        fail("Should have failed")
+      }
+      catch {
+        case tfe: TestFailedException =>
+          implicit val loc: At = cachedLoc
+          tfe.getMessage mustBe {
+            s"""$path:${l + 2} IO.raiseError[Int](new SmallError("Oops!")) failed (SmallError: Oops!)"""
+          }
+      }
+    }
+
+    "fail if the IO times out" in {
+      val cachedLoc = At.here
+      try {
+        valueOf(IO.sleep(quick).as(5))
+        fail("Should have failed")
+      }
+      catch {
+        case tfe: TestFailedException =>
+          implicit val loc: At = cachedLoc
+          tfe.getMessage mustBe s"""$path:${l + 2} IO.sleep(quick).as(5) timed out after $rightAway"""
+      }
+    }
+
+    "fail if the IO finalizers time out" in {
+      val long      = IO.sleep(3.seconds)
+      val cachedLoc = At.here
+      try {
+        valueOf(IO.pure(5).guaranteeCase(_ => long))
+        fail("Should have failed")
+      }
+      catch {
+        case tfe: TestFailedException =>
+          implicit val loc: At = cachedLoc
+          tfe.getMessage mustBe {
+            s"""$path:${l + 2} IO.pure(5).guaranteeCase(_ => long) timed out while running finalizers, after $quick"""
+          }
+      }
+    }
+
+    "fail if the IO finalizers fail" in {
+      val cachedLoc = At.here
+      try {
+        valueOf(
+          IO.pure(5).guaranteeCase(_ => IO.raiseError(new SmallError("Oops!")))
+        )
+        fail("Should have failed")
+      }
+      catch {
+        case tfe: TestFailedException =>
+          implicit val loc: At = cachedLoc
+          tfe.getMessage mustBe {
+            s"""$path:${l + 2} IO.pure(5).guaranteeCase(_ => IO.raiseError(new SmallError("Oops!"))) failed (SmallError: Oops!)"""
+          }
+      }
+    }
+  }
+
+  "valueOf[Future]" should {
+    "succeed if the Future succeeds" in {
+      valueOf(Future.successful(5)) mustBe 5
+    }
+
+    "fail if the Future fails" in {
+      val cachedLoc = At.here
+      try {
+        valueOf(Future.failed[Int](new SmallError("Oops!")))
+        fail("Should have failed")
+      }
+      catch {
+        case tfe: TestFailedException =>
+          implicit val loc: At = cachedLoc
+          tfe.getMessage mustBe {
+            s"""$path:${l + 2} Future.failed[Int](new SmallError("Oops!")) failed (SmallError: Oops!)"""
+          }
+      }
+    }
+
+    "fail if the Future times out" in {
+      def sleepFor(fd: FiniteDuration) = Future(Thread.sleep(fd.toMillis)).as(5)
+
+      val cachedLoc = At.here
+      try {
+        valueOf(sleepFor(10.seconds))
+        fail("Should have failed")
+      }
+      catch {
+        case tfe: TestFailedException =>
+          implicit val loc: At = cachedLoc
+          tfe.getMessage mustBe {
+            s"""$path:${l + 2} sleepFor(10.seconds) timed out after ${timeouts.total}""".stripMargin
+          }
+      }
+    }
+  }
+}

--- a/testing/src/peschke/testing/AssertionValueExtractors.scala
+++ b/testing/src/peschke/testing/AssertionValueExtractors.scala
@@ -1,0 +1,23 @@
+package peschke.testing
+
+import cats.syntax.show._
+
+/** Provides instances so [[ValueExtractor.Syntax]] can be used with raw
+  * assertions.
+  *
+  * This is mostly a bridge for when fully adapting [[ValueExtractor]] doesn't
+  * make sense
+  */
+trait AssertionValueExtractors extends ValueExtractor.Syntax[At] {
+  implicit val failUsingRawAssertions: Fail[At] = new Fail[At] {
+    override def apply[A](msg: String, sourceInfo: sourcecode.Text[A], at: At)
+      : Nothing =
+      throw new AssertionError(show"$at ${sourceInfo.source} $msg") // scalafix:ok DisableSyntax.throw
+
+    override def apply[A]
+      (msg: String, sourceInfo: sourcecode.Text[A], cause: Throwable, at: At)
+      : Nothing =
+      throw new AssertionError(s"$at ${sourceInfo.source} $msg", cause) // scalafix:ok DisableSyntax.throw
+  }
+}
+object AssertionValueExtractors extends AssertionValueExtractors

--- a/testing/src/peschke/testing/At.scala
+++ b/testing/src/peschke/testing/At.scala
@@ -1,0 +1,38 @@
+package peschke.testing
+
+import cats.Show
+
+/** Bundles the various bits of source location information needed to interface
+  * with testing libraries.
+  *
+  * This makes them easier to pass along without accidentally resetting the
+  * source location.
+  */
+final case class At
+  (path: sourcecode.File, name: sourcecode.FileName, line: sourcecode.Line) {
+  override def toString: String = s"${path.value}:${line.value}"
+}
+
+object At {
+  def here(
+            implicit filePath: sourcecode.File,
+            fileName:          sourcecode.FileName,
+            line:              sourcecode.Line): At =
+    At(filePath, fileName, line)
+
+  implicit val show: Show[At] = Show.fromToString
+
+  /** A typeclass that encodes the conversion between [[At]] and equivalent
+    * classes specific to each test framework
+    *
+    * Examples of this would be `munit.Location` or
+    * `org.scalactic.source.Position`
+    */
+  trait To[A] {
+    def from(at: At): A
+  }
+
+  object To {
+    implicit val toAt: At.To[At] = at => at
+  }
+}

--- a/testing/src/peschke/testing/Fail.scala
+++ b/testing/src/peschke/testing/Fail.scala
@@ -1,0 +1,34 @@
+package peschke.testing
+
+/** A typeclass that encodes the way a test framework can fail a test.
+  *
+  * @tparam Loc
+  *   A framework-specific breadcrumb equivalent-ish to [[At]]
+  */
+trait Fail[Loc] {
+
+  /** Fail a test with a message
+    * @param msg
+    *   the failure message
+    * @param sourceInfo
+    *   the source info of relevant input
+    * @param at
+    *   where the test failed
+    */
+  def apply[A](msg: String, sourceInfo: sourcecode.Text[A], at: Loc): Nothing
+
+  /** Fail a test with a message, capturing an exception
+    *
+    * @param msg
+    *   the failure message
+    * @param sourceInfo
+    *   the source info of relevant input
+    * @param cause
+    *   an exception that should be reported to the test framework
+    * @param at
+    *   where the test failed
+    */
+  def apply[A]
+    (msg: String, sourceInfo: sourcecode.Text[A], cause: Throwable, at: Loc)
+    : Nothing
+}

--- a/testing/src/peschke/testing/ValueExtractor.scala
+++ b/testing/src/peschke/testing/ValueExtractor.scala
@@ -1,0 +1,208 @@
+package peschke.testing
+
+import cats.Show
+import cats.data.Validated
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import cats.syntax.all._
+import sourcecode.Text
+
+import java.util.concurrent.TimeoutException
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+/** A typeclass that encodes the ability to extract a concrete value from an
+  * effect
+  *
+  * This isn't something that's normally a good idea in application code,
+  * however in tests it can be very handy to extract a value or fail the test
+  * gracefully if one is not available.
+  *
+  * @tparam F
+  *   the effect type
+  */
+trait ValueExtractor[F[_]] {
+
+  /** Extract a value of type `A` from inside an effect `F[_]`
+    * @param fa
+    *   the wrapped value, with source information. The conversion from `F[A]`
+    *   to `Text[F[A]]` is handled by macros, and should be transparent
+    * @param at
+    *   the location `valueOf` is being called, which will be reported to the
+    *   test framework in the case of failure
+    * @param fail
+    *   the test framework failure capability
+    * @param Loc
+    *   compatibility layer between [[At]] and `Loc`
+    * @tparam A
+    *   the type of the wrapped value
+    * @tparam Loc
+    *   the type the test framework uses to track failure locations
+    */
+  def valueOf[A, Loc](fa:          sourcecode.Text[F[A]])
+                     (implicit at: At, fail: Fail[Loc], Loc: At.To[Loc])
+    : A
+}
+
+object ValueExtractor {
+  def apply[F[_]](implicit VE: ValueExtractor[F]): VE.type = VE
+
+  /** Configuration for how long to wait before giving up on types like
+    * [[scala.concurrent.Future]] or [[cats.effect.IO]]
+    * @param primary
+    *   This is the timeout for the value itself
+    * @param finalization
+    *   In the case where the operation needs to be canceled, this is how long
+    *   we'll wait for this to complete. If `F` cannot be canceled, this is
+    *   taken as extra time for completion
+    */
+  final case class Timeouts
+    (primary: FiniteDuration, finalization: FiniteDuration) {
+    def total: FiniteDuration = primary + finalization
+  }
+
+  /** A mix-in base trait for creating mixins specific to each framework.
+    *
+    * The recommended pattern is to create a mixin trait that extends [[Syntax]]
+    * and provides the needed implicits for a particular `Loc`.
+    *
+    * @tparam Loc
+    *   the type the test framework uses to track failure locations
+    */
+  trait Syntax[Loc] {
+    def valueOf[F[_], A](fa: sourcecode.Text[F[A]])
+                        (
+                            implicit VE: ValueExtractor[F],
+                            path:        sourcecode.File,
+                            file:        sourcecode.FileName,
+                            line:        sourcecode.Line,
+                            fail:        Fail[Loc],
+                            loc:         At.To[Loc]
+      )
+      : A =
+      VE.valueOf(fa)(At.here, fail, loc)
+  }
+
+  implicit val optionCanExtractValue: ValueExtractor[Option] =
+    new ValueExtractor[Option] {
+      override def valueOf[A, Loc]
+        (fa:          sourcecode.Text[Option[A]])
+        (implicit at: At, fail: Fail[Loc], Loc: At.To[Loc])
+        : A =
+        fa.value.getOrElse(fail("was None", fa, Loc.from(at)))
+    }
+
+  implicit def eitherCanExtractValue[L: Show]: ValueExtractor[Either[L, *]] =
+    new ValueExtractor[Either[L, *]] {
+      override def valueOf[A, Loc]
+        (fa:          sourcecode.Text[Either[L, A]])
+        (implicit at: At, fail: Fail[Loc], Loc: At.To[Loc])
+        : A =
+        fa.value.valueOr { l =>
+          fail(show"was a Left($l) rather than a Right(_)", fa, Loc.from(at))
+        }
+    }
+
+  implicit def validatedCanExtractValue[L: Show]
+    : ValueExtractor[Validated[L, *]] =
+    new ValueExtractor[Validated[L, *]] {
+      override def valueOf[A, Loc]
+        (fa:          Text[Validated[L, A]])
+        (implicit at: At, fail: Fail[Loc], Loc: At.To[Loc])
+        : A =
+        fa.value.valueOr { l =>
+          fail(show"was an Invalid($l) rather than a Valid(_)", fa, Loc.from(at))
+        }
+    }
+
+  implicit val tryCanExtractValue: ValueExtractor[Try] =
+    new ValueExtractor[Try] {
+      override def valueOf[A, Loc]
+        (fa: Text[Try[A]])(implicit at: At, fail: Fail[Loc], Loc: At.To[Loc])
+        : A =
+        fa.value match {
+          case Failure(ex) =>
+            fail(
+              s"was a Failure(${ex.getClass.getSimpleName}: ${ex.getMessage}) rather than a Success(_)",
+              fa,
+              ex,
+              Loc.from(at)
+            )
+          case Success(value) => value
+        }
+    }
+
+  implicit def IOCanExtractValue
+    (implicit timeouts: ValueExtractor.Timeouts, runtime: IORuntime)
+    : ValueExtractor[IO] =
+    new ValueExtractor[IO] {
+      override def valueOf[A, Loc]
+        (fa:          sourcecode.Text[IO[A]])
+        (implicit at: At, fail: Fail[Loc], Loc: At.To[Loc])
+        : A = {
+        val limit = timeouts.primary
+        val total = timeouts.total
+        Either
+          .catchNonFatal {
+            fa.value
+              .timeout(limit)
+              .unsafeRunTimed(total)
+              .toRight(
+                s"timed out while running finalizers, after $total" -> none[
+                  Throwable
+                ]
+              )
+          }
+          .leftMap {
+            case _: TimeoutException =>
+              s"timed out after $limit" -> none[Throwable]
+            case ex =>
+              s"failed (${ex.getClass.getSimpleName}: ${ex.getMessage})" -> ex.some
+          }
+          .flatMap(identity)
+          .valueOr {
+            case (msg, Some(cause)) => fail(msg, fa, cause, Loc.from(at))
+            case (msg, None)        => fail(msg, fa, Loc.from(at))
+          }
+      }
+    }
+
+  implicit def FutureCanExtractValue(implicit timeouts: ValueExtractor.Timeouts)
+    : ValueExtractor[Future] =
+    new ValueExtractor[Future] {
+      override def valueOf[A, Loc]
+        (fa:          sourcecode.Text[Future[A]])
+        (implicit at: At, fail: Fail[Loc], Loc: At.To[Loc])
+        : A = {
+        val limit = timeouts.total
+
+        def futureTimedOut: (String, Option[Throwable]) =
+          s"timed out after $limit" -> none[Throwable]
+
+        def futureFailed(ex: Throwable): (String, Option[Throwable]) =
+          s"failed (${ex.getClass.getSimpleName}: ${ex.getMessage})" -> ex.some
+
+        Either
+          .catchNonFatal {
+            Await
+              .ready(fa.value, limit)
+              .value
+              .toRight(futureTimedOut)
+              .flatMap(_.toEither.leftMap(futureFailed))
+          }
+          .leftMap {
+            case _: TimeoutException | _: InterruptedException => futureTimedOut
+            case ex => futureFailed(ex)
+          }
+          .flatMap(identity)
+          .valueOr {
+            case (msg, Some(cause)) => fail(msg, fa, cause, Loc.from(at))
+            case (msg, None)        => fail(msg, fa, Loc.from(at))
+          }
+      }
+    }
+}

--- a/testing/test/src/peschke/testing/AssertionValueExtractorsTest.scala
+++ b/testing/test/src/peschke/testing/AssertionValueExtractorsTest.scala
@@ -1,0 +1,221 @@
+package peschke.testing
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import cats.syntax.all._
+import munit.Location
+import peschke.testing.ValueExtractor.Timeouts
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Try
+import scala.util.control.NoStackTrace
+
+class SmallError(msg: String)
+    extends IllegalArgumentException(msg)
+    with NoStackTrace
+
+class AssertionValueExtractorsTest
+    extends munit.FunSuite
+    with AssertionValueExtractors {
+  implicit private val runtime: IORuntime = IORuntime.global
+  implicit private val executionContext: ExecutionContext =
+    ExecutionContext.global
+
+  private val rightAway = 1.seconds
+  private val quick     = 2.seconds
+  implicit val timeouts: Timeouts = Timeouts(rightAway, rightAway)
+
+  private def path(implicit loc: Location): String = loc.path
+  private def l(implicit loc: Location):    Int    = loc.line
+
+  test("valueOf[Option[_]] should succeed on a Some(_)") {
+    assertEquals(valueOf(5.some), 5)
+  }
+
+  test("valueOf[Option] should fail on a None") {
+    val cachedLoc = implicitly[Location]
+    try {
+      valueOf(Option.empty[Int])
+      fail("Should have failed")
+    }
+    catch {
+      case ae: AssertionError =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          ae.getMessage,
+          s"""$path:${l + 2} Option.empty[Int] was None"""
+        )
+    }
+  }
+
+  test("valueOf[Either[_,_]] should succeed on a Right(_)") {
+    assertEquals(valueOf(Either.right[String, Int](5)), 5)
+  }
+
+  test("valueOf[Either[_,_]] should fail on a Left(_)") {
+    val cachedLoc = implicitly[Location]
+    try {
+      valueOf(Either.left[String, Int]("oops!"))
+      fail("Should have failed")
+    }
+    catch {
+      case ae: AssertionError =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          ae.getMessage,
+          s"""$path:${l + 2} Either.left[String, Int]("oops!") was a Left(oops!) rather than a Right(_)"""
+        )
+    }
+  }
+
+  test("valueOf[Validated[_,_]] should succeed on a Valid(_)") {
+    assertEquals(valueOf(5.valid[String]), 5)
+  }
+
+  test("valueOf[Validated[_,_]] should fail on an Invalid(_)") {
+    val cachedLoc = implicitly[Location]
+    try {
+      valueOf("oops!".invalid[Int])
+      fail("Should have failed")
+    }
+    catch {
+      case ae: AssertionError =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          ae.getMessage,
+          s"""$path:${l + 2} "oops!".invalid[Int] was an Invalid(oops!) rather than a Valid(_)"""
+        )
+    }
+  }
+
+  test("valueOf[Try[_]] should succeed on a Success(_)") {
+    assertEquals(valueOf(Try(5)), 5)
+  }
+
+  test("valueOf[Try[_]] should fail on a Failure(_)") {
+    val cachedLoc = implicitly[Location]
+    try {
+      valueOf(Failure(new SmallError("oops!")): Try[Int])
+      fail("Should have failed")
+    }
+    catch {
+      case ae: AssertionError =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          ae.getMessage,
+          s"""$path:${l + 2} Failure(new SmallError("oops!")): Try[Int] was a Failure(SmallError: oops!) rather than a Success(_)"""
+        )
+    }
+  }
+
+  test("valueOf[IO] should succeed if the IO succeeds and none of the finalizers time out") {
+    assertEquals(valueOf(IO.pure(5)), 5)
+  }
+
+  test("valueOf[IO] should fail if the IO fails") {
+    val cachedLoc = implicitly[Location]
+    try {
+      valueOf(IO.raiseError[Int](new SmallError("Oops!")))
+      fail("Should have failed")
+    }
+    catch {
+      case ae: AssertionError =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          ae.getMessage,
+          s"""$path:${l + 2} IO.raiseError[Int](new SmallError("Oops!")) failed (SmallError: Oops!)"""
+        )
+    }
+  }
+
+  test("valueOf[IO] should fail if the IO times out") {
+    val cachedLoc = implicitly[Location]
+    try {
+      valueOf(IO.sleep(quick).as(5))
+      fail("Should have failed")
+    }
+    catch {
+      case ae: AssertionError =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          ae.getMessage,
+          s"""$path:${l + 2} IO.sleep(quick).as(5) timed out after $rightAway""".stripMargin
+        )
+    }
+  }
+
+  test("valueOf[IO] should fail if the IO finalizers time out") {
+    val long      = IO.sleep(3.seconds)
+    val cachedLoc = implicitly[Location]
+    try {
+      valueOf(IO.pure(5).guaranteeCase(_ => long))
+      fail("Should have failed")
+    }
+    catch {
+      case ae: AssertionError =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          ae.getMessage,
+          s"""$path:${l + 2} IO.pure(5).guaranteeCase(_ => long) timed out while running finalizers, after $quick"""
+        )
+    }
+  }
+
+  test("valueOf[IO] should fail if the IO finalizers fail") {
+    val cachedLoc = implicitly[Location]
+    try {
+      valueOf(
+        IO.pure(5).guaranteeCase(_ => IO.raiseError(new SmallError("Oops!")))
+      )
+      fail("Should have failed")
+    }
+    catch {
+      case ae: AssertionError =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          ae.getMessage,
+          s"""$path:${l + 2} IO.pure(5).guaranteeCase(_ => IO.raiseError(new SmallError("Oops!"))) failed (SmallError: Oops!)"""
+        )
+    }
+  }
+
+  test("valueOf[Future] should succeed if the Future succeeds") {
+    assertEquals(valueOf(Future.successful(5)), 5)
+  }
+
+  test("valueOf[Future] should fail if the Future fails") {
+    val cachedLoc = implicitly[Location]
+    try {
+      valueOf(Future.failed[Int](new SmallError("Oops!")))
+      fail("Should have failed")
+    }
+    catch {
+      case ae: AssertionError =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          ae.getMessage,
+          s"""$path:${l + 2} Future.failed[Int](new SmallError("Oops!")) failed (SmallError: Oops!)"""
+        )
+    }
+  }
+
+  test("valueOf[Future] should fail if the Future times out") {
+    def sleepFor(fd: FiniteDuration) = Future(Thread.sleep(fd.toMillis)).as(5)
+    val cachedLoc                    = implicitly[Location]
+    try {
+      valueOf(sleepFor(10.seconds))
+      fail("Should have failed")
+    }
+    catch {
+      case ae: AssertionError =>
+        implicit val loc: Location = cachedLoc
+        assertEquals(
+          ae.getMessage,
+          s"""$path:${l + 2} sleepFor(10.seconds) timed out after ${timeouts.total}""".stripMargin
+        )
+    }
+  }
+}


### PR DESCRIPTION
# Abstract

Makes it easier to work with effects in tests, inspired by Scalatest's `EitherValues`, `ScalaFutures`, etc and munit's error reporting.

# Why include this?

The driving use case is `IO#unsafeRunSync` in existing tests, and there isn't sufficient resources to rewrite it completely in `IO` and use something like `munit-cats-effect`

As a bonus, this provides a nice way to get rid of `Option#get` calls.